### PR TITLE
Adds git clone and git checkout branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | gca          | `git commit -v -a`                                   |
 | `gca!`       | `git commit -v -a --amend`                           |
 | gcmsg        | `git commit -m`                                      |
+| gcl          | `git clone`                                          |
 | gco          | `git checkout`                                       |
 | gcod         | `git checkout develop`                               |
 | gcom         | `git checkout master`                                |
+| gcb          | `git checkout -b`                                    |
 | gcount       | `git shortlog -sn`                                   |
 | gcp          | `git cherry-pick`                                    |
 | gd           | `git diff`                                           |

--- a/init.fish
+++ b/init.fish
@@ -17,6 +17,7 @@ abbr -a gc!        git commit -v --amend
 abbr -a gca        git commit -v -a
 abbr -a gca!       git commit -v -a --amend
 abbr -a gcmsg      git commit -m
+abbr -a gcl        git clone
 abbr -a gcount     git shortlog -sn
 abbr -a gcp        git cherry-pick
 abbr -a gd         git diff
@@ -66,5 +67,6 @@ abbr -a gwch       git whatchanged -p --abbrev-commit --pretty=medium
 
 # git checkout abbreviations
 abbr -a gco        git checkout
+abbr -a gcb        git checkout -b
 abbr -a gcod       git checkout develop
 abbr -a gcom       git checkout master


### PR DESCRIPTION
These are the commands I most miss from migrating of zsh
I tried to keep it alphabetically sorted but on git clone I put gcl above gcm to keep commit commands together.