### PR TITLE
Add git commit --no-verify commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,12 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | gca          | `git commit -v -a`                                   |
 | `gca!`       | `git commit -v -a --amend`                           |
 | `gcan!`      | `git commit -v -a --no-edit --amend`                 |
+| gcv          | `git commit -v --no-verify`                          |
+| gcav         | `git commit -a -v --no-verify`                       |
+| gcav!        | `git commit -a -v --no-verify --amend`               |
 | gcm          | `git commit -m`                                      |
 | gcam         | `git commit -a -m`                                   |
-| gscam        | `git commit -S -a -m`
+| gscam        | `git commit -S -a -m`                                |
 
 ### Flow
 

--- a/init.fish
+++ b/init.fish
@@ -24,6 +24,9 @@ abbr -a gcn!       git commit -v --no-edit --amend
 abbr -a gca        git commit -v -a
 abbr -a gca!       git commit -v -a --amend
 abbr -a gcan!      git commit -v -a --no-edit --amend
+abbr -a gcv        git commit -v --no-verify
+abbr -a gcav       git commit -a -v --no-verify
+abbr -a gcav!      git commit -a -v --no-verify --amend
 abbr -a gcm        git commit -m
 abbr -a gcam       git commit -a -m
 abbr -a gscam      git commit -S -a -m


### PR DESCRIPTION
This PR adds three git commit commands with `--no-verify`, matching the same `v` suffix as the corresponding `git push --no-verify` commands. Also drive-by adds a `|` at the end of the commit command table