### PR TITLE
Port some functions from OMZ Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | Abbreviation | Command                                              |
 | ------------ | ---------------------------------------------------- |
 | gr           | `git remote -vv`                                     |
+| gra          | `git remote add`                                     |
 | grmv         | `git remote rename`                                  |
 | grrm         | `git remote remove`                                  |
 | grset        | `git remote set-url`                                 |

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | ------------ | --------------------------------------------------------    |
 | g            | `git`                                                       |
 | gap          | `git apply`                                                 |
-| gcf          | list git configuration                                      |
+| gcf          | `git config --list`                                         |
 | gcl          | `git clone`                                                 |
 | gclean       | pristine working directory: reset and force clean           |
 | gcp          | `git cherry-pick`                                           |

--- a/README.md
+++ b/README.md
@@ -128,12 +128,15 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | glr          | `git pull --rebase`                                  |
 | gp           | `git push`                                           |
 | gp!          | `git push --force-with-lease`                        |
+| gpo          | `git push origin`                                    |
+| gpo!         | `git push --force-with-lease origin`                 |
 | gpv          | `git push --no-verify`                               |
 | gpv!         | `git push --no-verify --force-with-lease`            |
 | ggp          | push origin _current-branch_                         |
+| ggp!         | `ggp --force-with-lease`                             |
+| gpu          | `ggp --set-upstream`                                 |
 | gpoat        | push all + tags to origin                            |
 | ggpnp        | pull & push origin _current-branch_                  |
-| gpu          | push --set-upsteam origin _current-branch_           |
 
 ### Rebase
 
@@ -184,7 +187,7 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | gtl          | list tags matching prefix                            |
 
 
-### Files
+### Local Files
 
 | Abbreviation | Command                                              |
 | ------------ | ---------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | gfo          | `git fetch origin`                                          |
 | gm           | `git merge`                                                 |
 | gmt          | `git mergetool --no-prompt`                                 |
+| grev         | `git revert`                                                |
 | grh          | `git reset HEAD`                                            |
 | grhh         | `git reset HEAD --hard`                                     |
 | grt          | cd into the top of the current repository or submodule      |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | gbD          | `git branch -D`                                      |
 | gbda         | delete all branches merged in current HEAD           |
 | ggsup        | git set upstream to origin/_current-branch_          |
-| grename      | Rename _old_ branch to _new_, including in origin remote |
+| grename      | rename _old_ branch to _new_, including in origin remote |
 
 ### Checkout
 
@@ -67,6 +67,18 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | gcm          | `git commit -m`                                      |
 | gcam         | `git commit -a -m`                                   |
 | gscam        | `git commit -S -a -m`                                |
+
+### Diff
+
+| Abbreviation | Command                                              |
+| ------------ | ---------------------------------------------------- |
+| gd           | `git diff`                                           |
+| gdca         | `git diff --cached`                                  |
+| gds          | `git diff --stat`                                    |
+| gdsc         | `git diff --stat --cached`                           |
+| gdw          | `git diff --word-diff`                               |
+| gdwc         | `git diff --word-diff --cached`                      |
+| gdv          | pipe `git diff` to `view` command                    |
 
 ### Flow
 
@@ -102,7 +114,7 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | glog         | `git log --oneline --decorate --color --graph`       |
 | glom         | `git log --oneline --decorate --color master..`      |
 | glod         | `git log --oneline --decorate --color develop..`     |
-| glp          | git log at requested pretty level                    |
+| glp          | `git log` at requested pretty level                  |
 | gwch         | `git whatchanged -p --abbrev-commit --pretty=medium` |
 
 ### Push & Pull
@@ -120,7 +132,7 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | ggp          | push origin _current-branch_                         |
 | gpoat        | push all + tags to origin                            |
 | ggpnp        | pull & push origin _current-branch_                  |
-| gpu          | git push --set-upsteam origin _current-branch_       |
+| gpu          | push --set-upsteam origin _current-branch_           |
 
 ### Rebase
 
@@ -185,11 +197,6 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | gcl          | `git clone`                                                 |
 | gclean       | pristine working directory: reset and force clean           |
 | gcp          | `git cherry-pick`                                           |
-| gd           | `git diff`                                                  |
-| gdca         | `git diff --cached`                                         |
-| gds          | `git diff --stat`                                           |
-| gdsc         | `git diff --stat --cached`                                  |
-| gdv          | pipe git diff to `view` command                             |
 | gignore      | `git update-index --assume-unchanged`                       |
 | gignored     | list temporarily ignored files                              |
 | gf           | `git fetch`                                                 |

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | ------------ | --------------------------------------------------------    |
 | g            | `git`                                                       |
 | gap          | `git apply`                                                 |
+| gbl          | `git blame -b -w`                                           |
 | gcf          | `git config --list`                                         |
 | gcl          | `git clone`                                                 |
 | gclean       | pristine working directory: reset and force clean           |

--- a/README.md
+++ b/README.md
@@ -175,6 +175,15 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | gwip         | commit a work-in-progress branch                     |
 | gunwip       | uncommit the work-in-progress branch                 |
 
+### Tags
+
+| Abbreviation | Command                                              |
+| ------------ | ---------------------------------------------------- |
+| gts          | `git tag -s`                                         |
+| gtv          | `git tag | sort -V`                                  |
+| gtl          | list tags matching prefix                            |
+
+
 ### Files
 
 | Abbreviation | Command                                              |

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | gban         | `git branch -a -v --no-merged`                       |
 | gbda         | delete all branches merged in current HEAD           |
 | ggsup        | git set upstream to origin/_current-branch_          |
+| grename      | Rename _old_ branch to _new_, including in origin remote |
 
 ### Checkout
 

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | Abbreviation | Command                                              |
 | ------------ | ---------------------------------------------------- |
 | gc           | `git commit -v`                                      |
-| `gc!`        | `git commit -v --amend`                              |
-| `gcn!`       | `git commit -v --no-edit --amend`                    |
+| gc!          | `git commit -v --amend`                              |
+| gcn!         | `git commit -v --no-edit --amend`                    |
 | gca          | `git commit -v -a`                                   |
-| `gca!`       | `git commit -v -a --amend`                           |
-| `gcan!`      | `git commit -v -a --no-edit --amend`                 |
+| gca!         | `git commit -v -a --amend`                           |
+| gcan!        | `git commit -v -a --no-edit --amend`                 |
 | gcv          | `git commit -v --no-verify`                          |
 | gcav         | `git commit -a -v --no-verify`                       |
 | gcav!        | `git commit -a -v --no-verify --amend`               |
@@ -169,6 +169,7 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | ga           | `git add`                                                   |
 | gaa          | `git add --all`                                             |
 | gapa         | `git add --patch`                                           |
+| gap          | `git apply`                                                 |
 | gcf          | list git configuration                                      |
 | gcl          | `git clone`                                                 |
 | gclean       | pristine working directory: reset and force clean           |

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | gcl          | `git clone`                                                 |
 | gclean       | pristine working directory: reset and force clean           |
 | gcp          | `git cherry-pick`                                           |
+| gcpa         | `git cherry-pick --abort`                                   |
+| gcpc         | `git cherry-pick --continue`                                |
 | gignore      | `git update-index --assume-unchanged`                       |
 | gignored     | list temporarily ignored files                              |
 | gf           | `git fetch`                                                 |

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | gdca         | `git diff --cached`                                  |
 | gds          | `git diff --stat`                                    |
 | gdsc         | `git diff --stat --cached`                           |
+| gdt          | list changed files                                   |
 | gdw          | `git diff --word-diff`                               |
 | gdwc         | `git diff --word-diff --cached`                      |
 | gdv          | pipe `git diff` to `view` command                    |

--- a/README.md
+++ b/README.md
@@ -161,14 +161,24 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | gwip         | commit a work-in-progress branch                     |
 | gunwip       | uncommit the work-in-progress branch                 |
 
+### Files
+
+| Abbreviation | Command                                              |
+| ------------ | ---------------------------------------------------- |
+| ga           | `git add`                                            |
+| gaa          | `git add --all`                                      |
+| gapa         | `git add --patch`                                    |
+| grm          | `git rm`                                             |
+| grmc         | `git rm --cached`                                    |
+| grs          | `git restore`                                        |
+| grss         | `git restore --source`                               |
+
+
 ### Everything Else
 
 | Abbreviation | Command                                                     |
 | ------------ | --------------------------------------------------------    |
 | g            | `git`                                                       |
-| ga           | `git add`                                                   |
-| gaa          | `git add --all`                                             |
-| gapa         | `git add --patch`                                           |
 | gap          | `git apply`                                                 |
 | gcf          | list git configuration                                      |
 | gcl          | `git clone`                                                 |
@@ -189,8 +199,6 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | gmt          | `git mergetool --no-prompt`                                 |
 | grh          | `git reset HEAD`                                            |
 | grhh         | `git reset HEAD --hard`                                     |
-| grs          | `git restore`                                               |
-| grss         | `git restore --source`                                      |
 | grt          | cd into the top of the current repository or submodule      |
 | gsh          | `git show`                                                  |
 | gsd          | `git svn dcommit`                                           |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ $ omf install https://github.com/jhillyerd/plugin-git
 | gb           | `git branch -vv`                                     |
 | gba          | `git branch -a -v`                                   |
 | gban         | `git branch -a -v --no-merged`                       |
+| gbd          | `git branch -d`                                      |
+| gbD          | `git branch -D`                                      |
 | gbda         | delete all branches merged in current HEAD           |
 | ggsup        | git set upstream to origin/_current-branch_          |
 | grename      | Rename _old_ branch to _new_, including in origin remote |

--- a/functions/__git.branch_has_wip.fish
+++ b/functions/__git.branch_has_wip.fish
@@ -1,7 +1,3 @@
 function __git.branch_has_wip -d "Returns 0 if branch has --wip--, otherwise 1"
-  if begin git log -n 1 ^/dev/null | grep -qc "\-\-wip\-\-"; end
-    return 0
-  else
-    return 1
-  end
+  git log -n 1 ^/dev/null | grep -qc "\-\-wip\-\-"
 end

--- a/functions/gcf.fish
+++ b/functions/gcf.fish
@@ -1,3 +1,3 @@
-function gcf -d "list git configuration"
+function gcf -d "List git configuration"
   git config --list
 end

--- a/functions/gcf.fish
+++ b/functions/gcf.fish
@@ -1,3 +1,0 @@
-function gcf -d "List git configuration"
-  git config --list
-end

--- a/functions/gdt.fish
+++ b/functions/gdt.fish
@@ -1,0 +1,3 @@
+function gdt -w "git diff" -d "List changed files"
+  git diff-tree --no-commit-id --name-only -r $argv
+end

--- a/functions/gdv.fish
+++ b/functions/gdv.fish
@@ -1,3 +1,3 @@
-function gdv -w "git diff -w" -d "Pipe git diff to `view` command"
+function gdv -w "git diff -w" -d "Pipe `git diff` to `view` command"
   git diff -w $argv | view -
 end

--- a/functions/ggl.fish
+++ b/functions/ggl.fish
@@ -1,3 +1,3 @@
-function ggl -d "git pull origin <current branch>"
-  git pull origin (__git.current_branch)
+function ggl -w "git pull origin master" -d "git pull origin <current branch>"
+  git pull origin (__git.current_branch) $argv
 end

--- a/functions/ggu.fish
+++ b/functions/ggu.fish
@@ -1,3 +1,3 @@
-function ggu -d "rebase the current branch on top of the upstream branch after fetching"
+function ggu -d "Rebase the current branch on top of the upstream branch after fetching"
   git pull --rebase origin (__git.current_branch)
 end

--- a/functions/glp.fish
+++ b/functions/glp.fish
@@ -1,7 +1,5 @@
-function glp -d "git log at requested pretty level"
-  if test (count $argv) -gt 0
-    git log --pretty=$argv[1]
-  end
+function glp -d "git log at requested pretty level" -a format
+  set -q format[1]; and git log --pretty=$format
 end
 
 complete -c glp -x -a "(complete -C 'git log --pretty=' | sed 's/^--pretty=//')"

--- a/functions/gpu.fish
+++ b/functions/gpu.fish
@@ -1,4 +1,0 @@
-function gpu -w "git push --set-upstream origin master" \
-             -d "git push --set-upstream origin <current branch>"
-  git push --set-upstream origin (__git.current_branch) $argv
-end

--- a/functions/grename.fish
+++ b/functions/grename.fish
@@ -1,0 +1,11 @@
+function grename -d "Rename 'old' branch to 'new', including in origin remote" -a old new
+  if test (count $argv) -ne 2
+    echo "Usage: "(status -u)" old_branch new_branch"
+    return 1
+  end
+  git branch -m $old $new
+  git push origin :$old
+  and git push --set-upstream origin $new
+end
+
+complete -c grename -x -a "(complete -C 'git branch ')"

--- a/functions/gtl.fish
+++ b/functions/gtl.fish
@@ -1,0 +1,3 @@
+function gtl -d "List tags matching prefix" -a prefix
+  git tag --sort=-v:refname -n -l $prefix\*
+end

--- a/init.fish
+++ b/init.fish
@@ -86,6 +86,8 @@ __git_abbr grbdia     git rebase master --interactive --autosquash
 __git_abbr grbs       git rebase --skip
 __git_abbr grh        git reset HEAD
 __git_abbr grhh       git reset HEAD --hard
+__git_abbr grm        git rm
+__git_abbr grmc       git rm --cached
 __git_abbr grmv       git remote rename
 __git_abbr grrm       git remote remove
 __git_abbr grs        git restore

--- a/init.fish
+++ b/init.fish
@@ -51,6 +51,8 @@ __git_abbr gd         git diff
 __git_abbr gdca       git diff --cached
 __git_abbr gds        git diff --stat
 __git_abbr gdsc       git diff --stat --cached
+__git_abbr gdw        git diff --word-diff
+__git_abbr gdwc       git diff --word-diff --cached
 __git_abbr gignore    git update-index --assume-unchanged
 __git_abbr gf         git fetch
 __git_abbr gfa        git fetch --all --prune

--- a/init.fish
+++ b/init.fish
@@ -84,6 +84,7 @@ __git_abbr grbd       git rebase develop
 __git_abbr grbdi      git rebase master --interactive
 __git_abbr grbdia     git rebase master --interactive --autosquash
 __git_abbr grbs       git rebase --skip
+__git_abbr grev       git revert
 __git_abbr grh        git reset HEAD
 __git_abbr grhh       git reset HEAD --hard
 __git_abbr grm        git rm

--- a/init.fish
+++ b/init.fish
@@ -21,6 +21,7 @@ __git_abbr g          git
 __git_abbr ga         git add
 __git_abbr gaa        git add --all
 __git_abbr gapa       git add --patch
+__git_abbr gap        git apply
 __git_abbr gba        git branch -a -v
 __git_abbr gban       git branch -a -v --no-merged
 __git_abbr gbd        git branch -d

--- a/init.fish
+++ b/init.fish
@@ -96,8 +96,8 @@ __git_abbr grbdi      git rebase master --interactive
 __git_abbr grbdia     git rebase master --interactive --autosquash
 __git_abbr grbs       git rebase --skip
 __git_abbr grev       git revert
-__git_abbr grh        git reset HEAD
-__git_abbr grhh       git reset HEAD --hard
+__git_abbr grh        git reset
+__git_abbr grhh       git reset --hard
 __git_abbr grm        git rm
 __git_abbr grmc       git rm --cached
 __git_abbr grmv       git remote rename

--- a/init.fish
+++ b/init.fish
@@ -22,11 +22,12 @@ __git_abbr ga         git add
 __git_abbr gaa        git add --all
 __git_abbr gapa       git add --patch
 __git_abbr gap        git apply
+__git_abbr gb         git branch -vv
 __git_abbr gba        git branch -a -v
 __git_abbr gban       git branch -a -v --no-merged
 __git_abbr gbd        git branch -d
 __git_abbr gbD        git branch -D
-__git_abbr gb         git branch -vv
+__git_abbr gbl        git blame -b -w
 __git_abbr gbs        git bisect
 __git_abbr gbsb       git bisect bad
 __git_abbr gbsg       git bisect good

--- a/init.fish
+++ b/init.fish
@@ -73,6 +73,7 @@ __git_abbr gp!        git push --force-with-lease
 __git_abbr gpv        git push --no-verify
 __git_abbr gpv!       git push --no-verify --force-with-lease
 __git_abbr gr         git remote -vv
+__git_abbr gra        git remote add
 __git_abbr grb        git rebase
 __git_abbr grba       git rebase --abort
 __git_abbr grbc       git rebase --continue

--- a/init.fish
+++ b/init.fish
@@ -114,6 +114,8 @@ __git_abbr gsts       git stash show --text
 __git_abbr gsu        git submodule update
 __git_abbr gsur       git submodule update --recursive
 __git_abbr gsuri      git submodule update --recursive --init
+__git_abbr gts        git tag -s
+__git_abbr gtv        git tag | sort -V
 __git_abbr gsw        git switch
 __git_abbr gswc       git switch --create
 __git_abbr gunignore  git update-index --no-assume-unchanged

--- a/init.fish
+++ b/init.fish
@@ -9,7 +9,7 @@ set -q __git_plugin_initialized; and exit 0
 
 set -U __git_plugin_abbreviations
 
-function __git.plugin_abbr -d "Create Git plugin abbreviation"
+function __git_abbr -d "Create Git plugin abbreviation"
   set -l name $argv[1]
   set -l body $argv[2..-1]
   abbr -a $name $body
@@ -17,126 +17,126 @@ function __git.plugin_abbr -d "Create Git plugin abbreviation"
 end
 
 # git abbreviations
-__git.plugin_abbr g          git
-__git.plugin_abbr ga         git add
-__git.plugin_abbr gaa        git add --all
-__git.plugin_abbr gapa       git add --patch
-__git.plugin_abbr gba        git branch -a -v
-__git.plugin_abbr gban       git branch -a -v --no-merged
-__git.plugin_abbr gb         git branch -vv
-__git.plugin_abbr gbs        git bisect
-__git.plugin_abbr gbsb       git bisect bad
-__git.plugin_abbr gbsg       git bisect good
-__git.plugin_abbr gbsr       git bisect reset
-__git.plugin_abbr gbss       git bisect start
-__git.plugin_abbr gc         git commit -v
-__git.plugin_abbr gc!        git commit -v --amend
-__git.plugin_abbr gcn!       git commit -v --no-edit --amend
-__git.plugin_abbr gca        git commit -v -a
-__git.plugin_abbr gca!       git commit -v -a --amend
-__git.plugin_abbr gcan!      git commit -v -a --no-edit --amend
-__git.plugin_abbr gcv        git commit -v --no-verify
-__git.plugin_abbr gcav       git commit -a -v --no-verify
-__git.plugin_abbr gcav!      git commit -a -v --no-verify --amend
-__git.plugin_abbr gcm        git commit -m
-__git.plugin_abbr gcam       git commit -a -m
-__git.plugin_abbr gscam      git commit -S -a -m
-__git.plugin_abbr gcl        git clone
-__git.plugin_abbr gcount     git shortlog -sn
-__git.plugin_abbr gcp        git cherry-pick
-__git.plugin_abbr gd         git diff
-__git.plugin_abbr gdca       git diff --cached
-__git.plugin_abbr gds        git diff --stat
-__git.plugin_abbr gdsc       git diff --stat --cached
-__git.plugin_abbr gignore    git update-index --assume-unchanged
-__git.plugin_abbr gf         git fetch
-__git.plugin_abbr gfa        git fetch --all --prune
-__git.plugin_abbr gfm        "git fetch origin master --prune; and git merge FETCH_HEAD"
-__git.plugin_abbr gfo        git fetch origin
-__git.plugin_abbr gl         git pull
-__git.plugin_abbr glr        git pull --rebase
-__git.plugin_abbr glg        git log --stat --max-count=10
-__git.plugin_abbr glgg       git log --graph --max-count=10
-__git.plugin_abbr glgga      git log --graph --decorate --all
-__git.plugin_abbr glo        git log --oneline --decorate --color
-__git.plugin_abbr glog       git log --oneline --decorate --color --graph
-__git.plugin_abbr glom       git log --oneline --decorate --color master..
-__git.plugin_abbr glod       git log --oneline --decorate --color develop..
-__git.plugin_abbr gloo       "git log --pretty=format:'%C(yellow)%h %Cred%ad %Cblue%an%Cgreen%d %Creset%s' --date=short"
-__git.plugin_abbr gm         git merge
-__git.plugin_abbr gmt        git mergetool --no-prompt
-__git.plugin_abbr gp         git push
-__git.plugin_abbr gp!        git push --force-with-lease
-__git.plugin_abbr gpv        git push --no-verify
-__git.plugin_abbr gpv!       git push --no-verify --force-with-lease
-__git.plugin_abbr gr         git remote -vv
-__git.plugin_abbr grb        git rebase
-__git.plugin_abbr grba       git rebase --abort
-__git.plugin_abbr grbc       git rebase --continue
-__git.plugin_abbr grbi       git rebase --interactive
-__git.plugin_abbr grbm       git rebase master
-__git.plugin_abbr grbmi      git rebase master --interactive
-__git.plugin_abbr grbmia     git rebase master --interactive --autosquash
-__git.plugin_abbr grbd       git rebase develop
-__git.plugin_abbr grbdi      git rebase master --interactive
-__git.plugin_abbr grbdia     git rebase master --interactive --autosquash
-__git.plugin_abbr grbs       git rebase --skip
-__git.plugin_abbr grh        git reset HEAD
-__git.plugin_abbr grhh       git reset HEAD --hard
-__git.plugin_abbr grmv       git remote rename
-__git.plugin_abbr grrm       git remote remove
-__git.plugin_abbr grs        git restore
-__git.plugin_abbr grset      git remote set-url
-__git.plugin_abbr grss       git restore --source
-__git.plugin_abbr grup       git remote update
-__git.plugin_abbr grv        git remote -v
-__git.plugin_abbr gsh        git show
-__git.plugin_abbr gsd        git svn dcommit
-__git.plugin_abbr gsr        git svn rebase
-__git.plugin_abbr gss        git status -s
-__git.plugin_abbr gst        git status
-__git.plugin_abbr gsta       git stash
-__git.plugin_abbr gstd       git stash drop
-__git.plugin_abbr gstp       git stash pop
-__git.plugin_abbr gsts       git stash show --text
-__git.plugin_abbr gsu        git submodule update
-__git.plugin_abbr gsur       git submodule update --recursive
-__git.plugin_abbr gsuri      git submodule update --recursive --init
-__git.plugin_abbr gsw        git switch
-__git.plugin_abbr gswc       git switch --create
-__git.plugin_abbr gunignore  git update-index --no-assume-unchanged
-__git.plugin_abbr gup        git pull --rebase
-__git.plugin_abbr gwch       git whatchanged -p --abbrev-commit --pretty=medium
+__git_abbr g          git
+__git_abbr ga         git add
+__git_abbr gaa        git add --all
+__git_abbr gapa       git add --patch
+__git_abbr gba        git branch -a -v
+__git_abbr gban       git branch -a -v --no-merged
+__git_abbr gb         git branch -vv
+__git_abbr gbs        git bisect
+__git_abbr gbsb       git bisect bad
+__git_abbr gbsg       git bisect good
+__git_abbr gbsr       git bisect reset
+__git_abbr gbss       git bisect start
+__git_abbr gc         git commit -v
+__git_abbr gc!        git commit -v --amend
+__git_abbr gcn!       git commit -v --no-edit --amend
+__git_abbr gca        git commit -v -a
+__git_abbr gca!       git commit -v -a --amend
+__git_abbr gcan!      git commit -v -a --no-edit --amend
+__git_abbr gcv        git commit -v --no-verify
+__git_abbr gcav       git commit -a -v --no-verify
+__git_abbr gcav!      git commit -a -v --no-verify --amend
+__git_abbr gcm        git commit -m
+__git_abbr gcam       git commit -a -m
+__git_abbr gscam      git commit -S -a -m
+__git_abbr gcl        git clone
+__git_abbr gcount     git shortlog -sn
+__git_abbr gcp        git cherry-pick
+__git_abbr gd         git diff
+__git_abbr gdca       git diff --cached
+__git_abbr gds        git diff --stat
+__git_abbr gdsc       git diff --stat --cached
+__git_abbr gignore    git update-index --assume-unchanged
+__git_abbr gf         git fetch
+__git_abbr gfa        git fetch --all --prune
+__git_abbr gfm        "git fetch origin master --prune; and git merge FETCH_HEAD"
+__git_abbr gfo        git fetch origin
+__git_abbr gl         git pull
+__git_abbr glr        git pull --rebase
+__git_abbr glg        git log --stat --max-count=10
+__git_abbr glgg       git log --graph --max-count=10
+__git_abbr glgga      git log --graph --decorate --all
+__git_abbr glo        git log --oneline --decorate --color
+__git_abbr glog       git log --oneline --decorate --color --graph
+__git_abbr glom       git log --oneline --decorate --color master..
+__git_abbr glod       git log --oneline --decorate --color develop..
+__git_abbr gloo       "git log --pretty=format:'%C(yellow)%h %Cred%ad %Cblue%an%Cgreen%d %Creset%s' --date=short"
+__git_abbr gm         git merge
+__git_abbr gmt        git mergetool --no-prompt
+__git_abbr gp         git push
+__git_abbr gp!        git push --force-with-lease
+__git_abbr gpv        git push --no-verify
+__git_abbr gpv!       git push --no-verify --force-with-lease
+__git_abbr gr         git remote -vv
+__git_abbr grb        git rebase
+__git_abbr grba       git rebase --abort
+__git_abbr grbc       git rebase --continue
+__git_abbr grbi       git rebase --interactive
+__git_abbr grbm       git rebase master
+__git_abbr grbmi      git rebase master --interactive
+__git_abbr grbmia     git rebase master --interactive --autosquash
+__git_abbr grbd       git rebase develop
+__git_abbr grbdi      git rebase master --interactive
+__git_abbr grbdia     git rebase master --interactive --autosquash
+__git_abbr grbs       git rebase --skip
+__git_abbr grh        git reset HEAD
+__git_abbr grhh       git reset HEAD --hard
+__git_abbr grmv       git remote rename
+__git_abbr grrm       git remote remove
+__git_abbr grs        git restore
+__git_abbr grset      git remote set-url
+__git_abbr grss       git restore --source
+__git_abbr grup       git remote update
+__git_abbr grv        git remote -v
+__git_abbr gsh        git show
+__git_abbr gsd        git svn dcommit
+__git_abbr gsr        git svn rebase
+__git_abbr gss        git status -s
+__git_abbr gst        git status
+__git_abbr gsta       git stash
+__git_abbr gstd       git stash drop
+__git_abbr gstp       git stash pop
+__git_abbr gsts       git stash show --text
+__git_abbr gsu        git submodule update
+__git_abbr gsur       git submodule update --recursive
+__git_abbr gsuri      git submodule update --recursive --init
+__git_abbr gsw        git switch
+__git_abbr gswc       git switch --create
+__git_abbr gunignore  git update-index --no-assume-unchanged
+__git_abbr gup        git pull --rebase
+__git_abbr gwch       git whatchanged -p --abbrev-commit --pretty=medium
 
 # git checkout abbreviations
-__git.plugin_abbr gco        git checkout
-__git.plugin_abbr gcb        git checkout -b
-__git.plugin_abbr gcod       git checkout develop
-__git.plugin_abbr gcom       git checkout master
+__git_abbr gco        git checkout
+__git_abbr gcb        git checkout -b
+__git_abbr gcod       git checkout develop
+__git_abbr gcom       git checkout master
 
 # git flow abbreviations
-__git.plugin_abbr gfb        git flow bugfix
-__git.plugin_abbr gff        git flow feature
-__git.plugin_abbr gfr        git flow release
-__git.plugin_abbr gfh        git flow hotfix
-__git.plugin_abbr gfs        git flow support
+__git_abbr gfb        git flow bugfix
+__git_abbr gff        git flow feature
+__git_abbr gfr        git flow release
+__git_abbr gfh        git flow hotfix
+__git_abbr gfs        git flow support
 
-__git.plugin_abbr gfbs       git flow bugfix start
-__git.plugin_abbr gffs       git flow feature start
-__git.plugin_abbr gfrs       git flow release start
-__git.plugin_abbr gfhs       git flow hotfix start
-__git.plugin_abbr gfss       git flow support start
+__git_abbr gfbs       git flow bugfix start
+__git_abbr gffs       git flow feature start
+__git_abbr gfrs       git flow release start
+__git_abbr gfhs       git flow hotfix start
+__git_abbr gfss       git flow support start
 
-__git.plugin_abbr gfbt       git flow bugfix track
-__git.plugin_abbr gfft       git flow feature track
-__git.plugin_abbr gfrt       git flow release track
-__git.plugin_abbr gfht       git flow hotfix track
-__git.plugin_abbr gfst       git flow support track
+__git_abbr gfbt       git flow bugfix track
+__git_abbr gfft       git flow feature track
+__git_abbr gfrt       git flow release track
+__git_abbr gfht       git flow hotfix track
+__git_abbr gfst       git flow support track
 
-__git.plugin_abbr gfp        git flow publish
+__git_abbr gfp        git flow publish
 
 # Cleanup declared functions
-functions -e __git.plugin_abbr
+functions -e __git_abbr
 
 # Mark git plugin as initialized
 set -U __git_plugin_initialized (date)

--- a/init.fish
+++ b/init.fish
@@ -48,6 +48,8 @@ __git_abbr gscam      git commit -S -a -m
 __git_abbr gcl        git clone
 __git_abbr gcount     git shortlog -sn
 __git_abbr gcp        git cherry-pick
+__git_abbr gcpa       git cherry-pick --abort
+__git_abbr gcpc       git cherry-pick --continue
 __git_abbr gd         git diff
 __git_abbr gdca       git diff --cached
 __git_abbr gds        git diff --stat

--- a/init.fish
+++ b/init.fish
@@ -62,6 +62,7 @@ __git_abbr gfa        git fetch --all --prune
 __git_abbr gfm        "git fetch origin master --prune; and git merge FETCH_HEAD"
 __git_abbr gfo        git fetch origin
 __git_abbr gl         git pull
+__git_abbr gll        git pull origin
 __git_abbr glr        git pull --rebase
 __git_abbr glg        git log --stat --max-count=10
 __git_abbr glgg       git log --graph --max-count=10
@@ -75,8 +76,12 @@ __git_abbr gm         git merge
 __git_abbr gmt        git mergetool --no-prompt
 __git_abbr gp         git push
 __git_abbr gp!        git push --force-with-lease
+__git_abbr gpo        git push origin
+__git_abbr gpo!       git push --force-with-lease origin
 __git_abbr gpv        git push --no-verify
 __git_abbr gpv!       git push --no-verify --force-with-lease
+__git_abbr ggp!       ggp --force-with-lease
+__git_abbr gpu        ggp --set-upstream
 __git_abbr gr         git remote -vv
 __git_abbr gra        git remote add
 __git_abbr grb        git rebase

--- a/init.fish
+++ b/init.fish
@@ -23,6 +23,8 @@ __git_abbr gaa        git add --all
 __git_abbr gapa       git add --patch
 __git_abbr gba        git branch -a -v
 __git_abbr gban       git branch -a -v --no-merged
+__git_abbr gbd        git branch -d
+__git_abbr gbD        git branch -D
 __git_abbr gb         git branch -vv
 __git_abbr gbs        git bisect
 __git_abbr gbsb       git bisect bad


### PR DESCRIPTION
I ported some functions from OMZ Git plugin. Most of them follow the OMZ Git's conventions, except some conflicting with current abbreviations - or to fit current convention.

I split them into small commits, so feel free to reject some of them if you think they don't fit current convention.