### PR TITLE
Add missing abbreviation: gcf

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -46,6 +46,7 @@ __git_abbr gcm        git commit -m
 __git_abbr gcam       git commit -a -m
 __git_abbr gscam      git commit -S -a -m
 __git_abbr gcfx       git commit --fixup
+__git_abbr gcf        git config --list
 __git_abbr gcl        git clone
 __git_abbr gclean     git clean -di
 __git_abbr gclean!    git clean -dfx


### PR DESCRIPTION
`gcf` was added to `README.md` in https://github.com/jhillyerd/plugin-git/pull/39 but the abbreviation definition for it wasn't included.