### PR TITLE
return instead of exit in __git.init

### DIFF
--- a/functions/__git.init.fish
+++ b/functions/__git.init.fish
@@ -6,7 +6,7 @@ function __git.init
     set -a __git_plugin_abbreviations $name
   end
 
-  set -q __git_plugin_initialized; and exit 0
+  set -q __git_plugin_initialized; and return 0
 
   set -U __git_plugin_abbreviations
 


### PR DESCRIPTION
`exit 0` causes the shell to exit/terminate when running `fisher update`. 

And since `__git.init` is a function now, it's completely fine to use `return 0` instead.