### PR TITLE
feat: use git init.defaultBranch if set

### DIFF
--- a/functions/__git.default_branch.fish
+++ b/functions/__git.default_branch.fish
@@ -1,8 +1,10 @@
 function __git.default_branch -d "Fallback to main when master branch is not found"
   # Silently fail when not in git directory
   command git rev-parse --git-dir &>/dev/null; or return
-  command git config --get init.defaultBranch; and return
-  if command git show-ref -q --verify refs/heads/master
+  set -l defaultBranch (command git config --get init.defaultBranch)
+  if command git show-ref -q --verify refs/heads/{$defaultBranch}
+    echo $defaultBranch
+  else if command git show-ref -q --verify refs/heads/master
     echo master
   else
     echo main

--- a/functions/__git.default_branch.fish
+++ b/functions/__git.default_branch.fish
@@ -1,6 +1,7 @@
 function __git.default_branch -d "Fallback to main when master branch is not found"
   # Silently fail when not in git directory
   command git rev-parse --git-dir &>/dev/null; or return
+  command git config --get init.defaultBranch; and return
   if command git show-ref -q --verify refs/heads/master
     echo master
   else


### PR DESCRIPTION
My first line of fish shell script, so please let me know if did anything off the hook!

The main goal of this PR is to use the return value for `git config --get init.defaultBranch`, if set, for function `__git.default_branch.fish`.