### PR TITLE
Fix: Error when init.defaultBranch isn't set

### DIFF
--- a/functions/__git.default_branch.fish
+++ b/functions/__git.default_branch.fish
@@ -1,13 +1,11 @@
 function __git.default_branch -d "Fallback to main when master branch is not found"
-  # Silently fail when not in git directory
   command git rev-parse --git-dir &>/dev/null; or return
-  set -l defaultBranch (command git config --get init.defaultBranch)
-  if command git show-ref -q --verify refs/heads/{$defaultBranch}
-    echo $defaultBranch
+  if set -l default_branch (command git config --get init.defaultBranch)
+    and command git show-ref -q --verify refs/heads/{$default_branch}
+    echo $default_branch
   else if command git show-ref -q --verify refs/heads/master
     echo master
   else
     echo main
   end
-end  
-
+end

--- a/functions/__git.destroy.fish
+++ b/functions/__git.destroy.fish
@@ -1,6 +1,6 @@
 function __git.destroy
   for ab in $__git_plugin_abbreviations
-      abbr -e $ab
+    abbr -e $ab
   end
   set -Ue __git_plugin_abbreviations
   set -Ue __git_plugin_initialized

--- a/functions/ggpnp.fish
+++ b/functions/ggpnp.fish
@@ -1,3 +1,5 @@
 function ggpnp -d "git pull & push origin <current branch>"
-  git pull origin (__git.current_branch); and git push origin (__git.current_branch)
+  set -l current_branch (__git.current_branch)
+  and git pull origin $current_branch
+  and git push origin $current_branch
 end


### PR DESCRIPTION
Fix a bug caused by https://github.com/jhillyerd/plugin-git/pull/61

```
❯ git checkout (__git.default_branch)
fatal: --verify requires a reference
Already on 'master'
Your branch is up to date with 'origin/master'.
```