### PR TITLE
Clear ambiguity of pipe symbol in Markdown code

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ $ fisher install jhillyerd/plugin-git
 | Abbreviation | Command                                              |
 | ------------ | ---------------------------------------------------- |
 | gts          | `git tag -s`                                         |
-| gtv          | `git tag | sort -V`                                  |
+| gtv          | `git tag \| sort -V`                                 |
 | gtl          | list tags matching prefix                            |
 
 


### PR DESCRIPTION
The pipe '|' was interpreted as column delimiter, but it is actually just a pipe symbol.