### PR TITLE
Add gup variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ $ fisher install jhillyerd/plugin-git
 | gl           | `git pull`                                           |
 | ggl          | pull origin _current-branch_                         |
 | gup          | `git pull --rebase`                                  |
+| gupv         | `git pull --rebase -v`                               |
+| gupa         | `git pull --rebase --autostash`                      |
+| gupav        | `git pull --rebase --autostash -v`                   |
 | glr          | `git pull --rebase`                                  |
 | gp           | `git push`                                           |
 | gp!          | `git push --force-with-lease`                        |

--- a/functions/__git.init.fish
+++ b/functions/__git.init.fish
@@ -126,6 +126,9 @@ function __git.init
   __git.create_abbr gswc       git switch --create
   __git.create_abbr gunignore  git update-index --no-assume-unchanged
   __git.create_abbr gup        git pull --rebase
+  __git.create_abbr gupv       git pull --rebase -v
+  __git.create_abbr gupa       git pull --rebase --autostash
+  __git.create_abbr gupav      git pull --rebase --autostash -v
   __git.create_abbr gwch       git whatchanged -p --abbrev-commit --pretty=medium
 
   # git checkout abbreviations


### PR DESCRIPTION
I added the following three `gup` variants:

| Abbreviation | Command                                              |
| ------------ | ---------------------------------------------------- |
| gupv         | `git pull --rebase -v`                               |
| gupa         | `git pull --rebase --autostash`                      |
| gupav        | `git pull --rebase --autostash -v`                   |

Inspired by ohmyzsh:

https://github.com/ohmyzsh/ohmyzsh/blob/190325049ef93731ab28295dbedf36d44ab33d7a/plugins/git/git.plugin.zsh#L298-L300