### PR TITLE
Remove --max-count=10 from log subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ The order for resolving the default branch name is as follows:
 | Abbreviation | Command                                              |
 | ------------ | ---------------------------------------------------- |
 | gcount       | `git shortlog -sn`                                   |
-| glg          | `git log --stat --max-count=10`                      |
-| glgg         | `git log --graph --max-count=10`                     |
+| glg          | `git log --stat`                                     |
+| glgg         | `git log --graph`                                    |
 | glgga        | `git log --graph --decorate --all`                   |
 | glo          | `git log --oneline --decorate --color`               |
 | gloo         | `git log --pretty=format:'%C(yellow)%h %Cred%ad %Cblue%an%Cgreen%d %Creset%s' --date=short` |

--- a/functions/__git.init.fish
+++ b/functions/__git.init.fish
@@ -65,8 +65,8 @@ function __git.init
   __git.create_abbr gl         git pull
   __git.create_abbr gll        git pull origin
   __git.create_abbr glr        git pull --rebase
-  __git.create_abbr glg        git log --stat --max-count=10
-  __git.create_abbr glgg       git log --graph --max-count=10
+  __git.create_abbr glg        git log --stat
+  __git.create_abbr glgg       git log --graph
   __git.create_abbr glgga      git log --graph --decorate --all
   __git.create_abbr glo        git log --oneline --decorate --color
   __git.create_abbr glog       git log --oneline --decorate --color --graph


### PR DESCRIPTION
Feel free to not merge this PR. But I feel having max-count just creates more friction when you want to actually see more than 10 commits, whereas you can just press q if you're satisfied with less than 10.