### PR TITLE
Add `grpo` alias to delete stale refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ The order for resolving the default branch name is as follows:
 | gr           | `git remote -vv`                                     |
 | gra          | `git remote add`                                     |
 | grmv         | `git remote rename`                                  |
+| grpo         | `git remote prune origin`                            |
 | grrm         | `git remote remove`                                  |
 | grset        | `git remote set-url`                                 |
 | grup         | `git remote update`                                  |

--- a/functions/__git.init.fish
+++ b/functions/__git.init.fish
@@ -105,6 +105,7 @@ function __git.init
   __git.create_abbr grm        git rm
   __git.create_abbr grmc       git rm --cached
   __git.create_abbr grmv       git remote rename
+  __git.create_abbr grpo       git remote prune origin
   __git.create_abbr grrm       git remote remove
   __git.create_abbr grs        git restore
   __git.create_abbr grset      git remote set-url


### PR DESCRIPTION
This PR includes: 
 - `grpo` => `git remote prune origin`
  - Equivalent to `git fetch --prune <name>`, except that no new references will be fetched
___

I like to use this to cleanup stale references without having to fetch new references.