### PR TITLE
Add gpoh alias to push origin current branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ The order for resolving the default branch name is as follows:
 | gp!          | `git push --force-with-lease`                        |
 | gpo          | `git push origin`                                    |
 | gpo!         | `git push --force-with-lease origin`                 |
+| gpoh         | `git push origin HEAD`                 |
 | gpv          | `git push --no-verify`                               |
 | gpv!         | `git push --no-verify --force-with-lease`            |
 | ggp          | push origin _current-branch_                         |

--- a/functions/__git.init.fish
+++ b/functions/__git.init.fish
@@ -81,6 +81,7 @@ function __git.init
   __git.create_abbr gp!        git push --force-with-lease
   __git.create_abbr gpo        git push origin
   __git.create_abbr gpo!       git push --force-with-lease origin
+  __git.create_abbr gpoh       git push origin HEAD
   __git.create_abbr gpv        git push --no-verify
   __git.create_abbr gpv!       git push --no-verify --force-with-lease
   __git.create_abbr ggp!       ggp --force-with-lease


### PR DESCRIPTION
`git push origin HEAD` can quickly push branches created  from other remote upstream branches