### PR TITLE
Delete squashed branches in gbda

### DIFF
--- a/functions/gbda.fish
+++ b/functions/gbda.fish
@@ -1,5 +1,14 @@
-function gbda -d "Delete all branches merged in current HEAD"
+function gbda -d "Delete all branches merged in current HEAD, including squashed"
   git branch --merged | \
     command grep -vE  '^\*|^\s*(master|main|develop)\s*$' | \
     command xargs -n 1 git branch -d
+
+  set -l default_branch (__git.default_branch)
+  git for-each-ref refs/heads/ "--format=%(refname:short)" | \
+    while read branch
+      set -l merge_base (git merge-base $default_branch $branch)
+      if string match -q -- '-*' (git cherry $default_branch (git commit-tree (git rev-parse $branch\^{tree}) -p $merge_base -m _))
+        git branch -D $branch
+      end
+    end
 end


### PR DESCRIPTION
This adds functionality to the `gbda` function to delete branches that have been squash merged.

Based on shell code from https://github.com/not-an-aardvark/git-delete-squashed