### PR TITLE
Fix 9313 universal abbr

### DIFF
--- a/conf.d/git.fish
+++ b/conf.d/git.fish
@@ -1,4 +1,4 @@
-function _git_install --on-event git_install
+function _git_init --on-event fish_prompt
   __git.init
 end
 

--- a/functions/__git.init.fish
+++ b/functions/__git.init.fish
@@ -6,8 +6,6 @@ function __git.init
     set -a __git_plugin_abbreviations $name
   end
 
-  set -q __git_plugin_initialized; and return 0
-
   set -U __git_plugin_abbreviations
 
   # git abbreviations


### PR DESCRIPTION
Fixes two issues:

1. Upstream [issue 9313 ](https://github.com/fish-shell/fish-shell/pull/9313) changes how abbreviations work. They are no longer universal and need to get loaded on every interactive prompt (but also they are much faster so it doesn't matter as much). This fix loads in these abbreviations on every call to `__git.init`

2. fisher installations without oh-my-fish (like mine) don't call anything in the `hooks` directory. So these abbreviations aren't loaded on subsequent new shells. Triggering `_git_init` on interactive prompts fixes this.

I am running this current config on my installation and seems to work as intended.