### PR TITLE
Add gtest function: tests staged changes w/ specified command

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ The order for resolving the default branch name is as follows:
 | gstl         | `git stash list`                                     |
 | gstp         | `git stash pop`                                      |
 | gsts         | `git stash show --text`                              |
+| gtest        | runs specified command against staged files only     |
 | gwip         | commit a work-in-progress branch                     |
 | gunwip       | uncommit the work-in-progress branch                 |
 

--- a/functions/gtest.fish
+++ b/functions/gtest.fish
@@ -13,8 +13,7 @@ function gtest -d "test command on staged changes only"
   git restore .
 
   # Return working dir and index to original state.
-  git reset -q HEAD^
-  git add --all
+  git reset --soft HEAD~1
   git stash pop -q
 
   return $cmdstatus

--- a/functions/gtest.fish
+++ b/functions/gtest.fish
@@ -3,18 +3,19 @@
 # example usage:
 #   gtest make test
 function gtest -d "test command on staged changes only"
-  # Commit index changes, stash everything else.
-  git commit -q --no-verify -m "WIP: testing index with $cmd"; or return
-  git stash push -q --include-untracked; or return
+  # Stash working dir, keeping index changes.
+  git stash push -q --keep-index --include-untracked; or return
 
   # Run test command and cleanup any trackable output.
   command $argv
   set cmdstatus $status
-  git restore .
 
   # Return working dir and index to original state.
-  git reset --soft HEAD~1
-  git stash pop -q
+  # Note: reset + restore is required to prevent merge conflicts
+  # when popping the stash.
+  git reset
+  git restore .
+  git stash pop -q --index; or return $status
 
   return $cmdstatus
 end

--- a/functions/gtest.fish
+++ b/functions/gtest.fish
@@ -6,14 +6,14 @@ function gtest -d "test command on staged changes only"
   # Stash working dir, keeping index changes.
   git stash push -q --keep-index --include-untracked; or return
 
-  # Run test command and cleanup any trackable output.
+  # Run test command against index changes only.
   command $argv
   set cmdstatus $status
 
   # Return working dir and index to original state.
   # Note: reset + restore is required to prevent merge conflicts
   # when popping the stash.
-  git reset
+  git reset -q
   git restore .
   git stash pop -q --index; or return $status
 

--- a/functions/gtest.fish
+++ b/functions/gtest.fish
@@ -1,0 +1,21 @@
+# gtest: test a command against git staged changes.
+#
+# example usage:
+#   gtest make test
+function gtest -d "test command on staged changes only"
+  # Commit index changes, stash everything else.
+  git commit -q --no-verify -m "WIP: testing index with $cmd"; or return
+  git stash push -q --include-untracked; or return
+
+  # Run test command and cleanup any trackable output.
+  command $argv
+  set cmdstatus $status
+  git restore .
+
+  # Return working dir and index to original state.
+  git reset -q HEAD^
+  git add --all
+  git stash pop -q
+
+  return $cmdstatus
+end


### PR DESCRIPTION
Anyone viewing this PR, please comment if you know an easier way to accomplish this.

To do:

- [x] Try `git reset --soft HEAD~1` to reset & stage in one step
- [x] Try again with `push --keep-index`, this time discard index after testing then pop stash

Good discussion: https://stackoverflow.com/questions/41304610/run-tests-only-for-staged-files-git-stash-k-u-and-git-stash-pop-will-rais
