### PR TITLE
Add Gitlab-specific push options

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,13 @@ The order for resolving the default branch name is as follows:
 | gwtpr        | `git worktree prune`                                 |
 | gwtulo       | `git worktree unlock`                                |
 
+### GitLab-specific [push options](https://docs.gitlab.com/ee/user/project/push_options.html)
+
+| Abbreviation | Command                                              |
+| ------------ | ---------------------------------------------------- |
+| gmr          | Push current branch and create a merge request from it |
+| gmwps        | Same as `gmr` but set the merge request to merge when the pipeline succeeds |
+
 ### Everything Else
 
 | Abbreviation | Command                                                     |

--- a/functions/__git.init.fish
+++ b/functions/__git.init.fish
@@ -182,6 +182,10 @@ function __git.init
   __git.create_abbr gwtrm      git worktree remove
   __git.create_abbr gwtulo     git worktree unlock
 
+  # GitLab push options
+  __git.create_abbr gmr        ggp --set-upstream -o merge_request.create
+  __git.create_abbr gmwps      ggp --set-upstream -o merge_request.create -o merge_request.merge_when_pipeline_succeeds
+
   # Cleanup declared functions
   functions -e __git.create_abbr
 end


### PR DESCRIPTION
Add aliases to common GitLab push options. The push options flag is a builtin `git` feature, but these option names are specific to GitLab.