### PR TITLE
Load configuration via fisher_path

### DIFF
--- a/conf.d/git.fish
+++ b/conf.d/git.fish
@@ -3,7 +3,8 @@
 functions -e _git_install _git_update _git_uninstall
 
 # fisher initialization, protected as omf also tries to run it.
-if test -f $__fish_config_dir/functions/__git.init.fish
-  source $__fish_config_dir/functions/__git.init.fish
+set -q fisher_path; or set -l fisher_path $__fish_config_dir
+if test -f $fisher_path/functions/__git.init.fish
+  source $fisher_path/functions/__git.init.fish
   __git.init
 end


### PR DESCRIPTION
I installed the plugin in the specified directory through fisher_path, so this pr tries to use fisher_path as a backup directory