### PR TITLE
Use abbreviations instead of functions for simple aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ gunwip           # restore work in progress
 | gdca         | `git diff --cached`                                  |
 | gds          | `git diff --stat`                                    |
 | gdsc         | `git diff --stat --cached`                           |
-| gdt          | `git diff-tree --no-commit-id --name-only -r`        |
+| gdt          | list changed files                                   |
 | gdw          | `git diff --word-diff`                               |
 | gdwc         | `git diff --word-diff --cached`                      |
 | gdto         | `git difftool`                                       |
@@ -236,7 +236,7 @@ gunwip           # restore work in progress
 | ggp!         | `git push origin (__git.current_branch) --force-with-lease`   |
 | gpu          | `git push origin (__git.current_branch) --set-upstream`       |
 | gpoat        | `git push origin --all; and git push origin --tags`  |
-| ggpnp        | `git pull origin (__git.current_branch); and git push origin (__git.current_branch)`    |
+| ggpnp        | pull & push origin _current-branch_                  |
 
 ### Rebase
 

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ gunwip           # restore work in progress
 | gbD          | `git branch -D`                                      |
 | gbda         | delete all branches merged in current HEAD           |
 | gbage        | list local branches and display their age            |
-| ggsup        | git set upstream to origin/_current-branch_          |
-| grename      | rename _old_ branch to _new_, including in origin remote |
+| ggsup        | `git branch --set-upstream-to=origin/(__git.current_branch)`  |
+| grename      | rename _old_ branch to _new_, including in origin remote      |
 
 ### Checkout
 
@@ -171,7 +171,7 @@ gunwip           # restore work in progress
 | gdca         | `git diff --cached`                                  |
 | gds          | `git diff --stat`                                    |
 | gdsc         | `git diff --stat --cached`                           |
-| gdt          | list changed files                                   |
+| gdt          | `git diff-tree --no-commit-id --name-only -r`        |
 | gdw          | `git diff --word-diff`                               |
 | gdwc         | `git diff --word-diff --cached`                      |
 | gdto         | `git difftool`                                       |
@@ -220,7 +220,7 @@ gunwip           # restore work in progress
 | Abbreviation | Command                                              |
 | ------------ | ---------------------------------------------------- |
 | gl           | `git pull`                                           |
-| ggl          | pull origin _current-branch_                         |
+| ggl          | `git pull origin (__git.current_branch)`             |
 | gup          | `git pull --rebase`                                  |
 | gupv         | `git pull --rebase -v`                               |
 | gupa         | `git pull --rebase --autostash`                      |
@@ -232,11 +232,11 @@ gunwip           # restore work in progress
 | gpo!         | `git push --force-with-lease origin`                 |
 | gpv          | `git push --no-verify`                               |
 | gpv!         | `git push --no-verify --force-with-lease`            |
-| ggp          | push origin _current-branch_                         |
-| ggp!         | `ggp --force-with-lease`                             |
-| gpu          | `ggp --set-upstream`                                 |
-| gpoat        | push all + tags to origin                            |
-| ggpnp        | pull & push origin _current-branch_                  |
+| ggp          | `git push origin (__git.current_branch)`             |
+| ggp!         | `git push origin (__git.current_branch) --force-with-lease`   |
+| gpu          | `git push origin (__git.current_branch) --set-upstream`       |
+| gpoat        | `git push origin --all; and git push origin --tags`  |
+| ggpnp        | `git pull origin (__git.current_branch); and git push origin (__git.current_branch)`    |
 
 ### Rebase
 
@@ -256,7 +256,7 @@ gunwip           # restore work in progress
 | grbdi        | `git rebase develop --interactive`                   |
 | grbdia       | `git rebase develop --interactive --autosquash`      |
 | grbs         | `git rebase --skip`                                  |
-| ggu          | fetch & rebase _current-branch_ on top of the upstream branch |
+| ggu          | `git pull --rebase origin \(__git.current_branch\)`  |
 
 ### Remote
 

--- a/functions/__git.init.fish
+++ b/functions/__git.init.fish
@@ -27,6 +27,7 @@ function __git.init
   __git.create_abbr gban       git branch -a -v --no-merged
   __git.create_abbr gbd        git branch -d
   __git.create_abbr gbD        git branch -D
+  __git.create_abbr ggsup      git branch --set-upstream-to=origin/\(__git.current_branch\)
   __git.create_abbr gbl        git blame -b -w
   __git.create_abbr gbs        git bisect
   __git.create_abbr gbsb       git bisect bad
@@ -59,6 +60,7 @@ function __git.init
   __git.create_abbr gdca       git diff --cached
   __git.create_abbr gds        git diff --stat
   __git.create_abbr gdsc       git diff --stat --cached
+  __git.create_abbr gdt        git diff-tree --no-commit-id --name-only -r
   __git.create_abbr gdw        git diff --word-diff
   __git.create_abbr gdwc       git diff --word-diff --cached
   __git.create_abbr gdto       git difftool
@@ -68,6 +70,7 @@ function __git.init
   __git.create_abbr gfm        "git fetch origin (__git.default_branch) --prune; and git merge FETCH_HEAD"
   __git.create_abbr gfo        git fetch origin
   __git.create_abbr gl         git pull
+  __git.create_abbr ggl        git pull origin \(__git.current_branch\)
   __git.create_abbr gll        git pull origin
   __git.create_abbr glr        git pull --rebase
   __git.create_abbr glg        git log --stat
@@ -88,8 +91,11 @@ function __git.init
   __git.create_abbr gpo!       git push --force-with-lease origin
   __git.create_abbr gpv        git push --no-verify
   __git.create_abbr gpv!       git push --no-verify --force-with-lease
-  __git.create_abbr ggp!       ggp --force-with-lease
-  __git.create_abbr gpu        ggp --set-upstream
+  __git.create_abbr ggp        git push origin \(__git.current_branch\)
+  __git.create_abbr ggp!       git push origin \(__git.current_branch\) --force-with-lease
+  __git.create_abbr gpu        git push origin \(__git.current_branch\) --set-upstream
+  __git.create_abbr gpoat      "git push origin --all; and git push origin --tags"
+  __git.create_abbr ggpnp      "git pull origin (__git.current_branch); and git push origin (__git.current_branch)"
   __git.create_abbr gr         git remote -vv
   __git.create_abbr gra        git remote add
   __git.create_abbr grb        git rebase
@@ -106,6 +112,7 @@ function __git.init
   __git.create_abbr grbdi      git rebase develop --interactive
   __git.create_abbr grbdia     git rebase develop --interactive --autosquash
   __git.create_abbr grbs       git rebase --skip
+  __git.create_abbr ggu        git pull --rebase origin \(__git.current_branch\)
   __git.create_abbr grev       git revert
   __git.create_abbr grh        git reset
   __git.create_abbr grhh       git reset --hard
@@ -183,8 +190,8 @@ function __git.init
   __git.create_abbr gwtulo     git worktree unlock
 
   # GitLab push options
-  __git.create_abbr gmr        ggp --set-upstream -o merge_request.create
-  __git.create_abbr gmwps      ggp --set-upstream -o merge_request.create -o merge_request.merge_when_pipeline_succeeds
+  __git.create_abbr gmr        git push origin \(__git.current_branch\) --set-upstream -o merge_request.create
+  __git.create_abbr gmwps      git push origin \(__git.current_branch\) --set-upstream -o merge_request.create -o merge_request.merge_when_pipeline_succeeds
 
   # Cleanup declared functions
   functions -e __git.create_abbr

--- a/functions/gdt.fish
+++ b/functions/gdt.fish
@@ -1,3 +1,0 @@
-function gdt -w "git diff" -d "List changed files"
-  git diff-tree --no-commit-id --name-only -r $argv
-end

--- a/functions/ggl.fish
+++ b/functions/ggl.fish
@@ -1,3 +1,0 @@
-function ggl -w "git pull origin master" -d "git pull origin <current branch>"
-  git pull origin (__git.current_branch) $argv
-end

--- a/functions/ggp.fish
+++ b/functions/ggp.fish
@@ -1,3 +1,0 @@
-function ggp -w "git push origin master" -d "git push origin <current branch>"
-  git push origin (__git.current_branch) $argv
-end

--- a/functions/ggpnp.fish
+++ b/functions/ggpnp.fish
@@ -1,5 +1,0 @@
-function ggpnp -d "git pull & push origin <current branch>"
-  set -l current_branch (__git.current_branch)
-  and git pull origin $current_branch
-  and git push origin $current_branch
-end

--- a/functions/ggsup.fish
+++ b/functions/ggsup.fish
@@ -1,3 +1,0 @@
-function ggsup -d "git set upstream to origin/<current branch>"
-  git branch --set-upstream-to=origin/(__git.current_branch)
-end

--- a/functions/ggu.fish
+++ b/functions/ggu.fish
@@ -1,3 +1,0 @@
-function ggu -d "Rebase the current branch on top of the upstream branch after fetching"
-  git pull --rebase origin (__git.current_branch)
-end

--- a/functions/gpoat.fish
+++ b/functions/gpoat.fish
@@ -1,3 +1,0 @@
-function gpoat -d "git push all + tags to origin"
-  git push origin --all; and git push origin --tags
-end


### PR DESCRIPTION
I think it would be nice to use abbreviations instead of functions when possible because it allows the user to see the full command easily.

Closes https://github.com/jhillyerd/plugin-git/issues/97