### PR TITLE
Add `gcs` abbreviation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ gunwip           # restore work in progress
 | gcav!        | `git commit -a -v --no-verify --amend`               |
 | gcm          | `git commit -m`                                      |
 | gcam         | `git commit -a -m`                                   |
+| gcs          | `git commit -S`                                      |
 | gscam        | `git commit -S -a -m`                                |
 | gcfx         | `git commit --fixup`                                 |
 

--- a/functions/__git.init.fish
+++ b/functions/__git.init.fish
@@ -44,6 +44,7 @@ function __git.init
   __git.create_abbr gcav       git commit -a -v --no-verify
   __git.create_abbr gcav!      git commit -a -v --no-verify --amend
   __git.create_abbr gcm        git commit -m
+  __git.create_abbr gcs        git commit -S
   __git.create_abbr gcam       git commit -a -m
   __git.create_abbr gscam      git commit -S -a -m
   __git.create_abbr gcfx       git commit --fixup

--- a/functions/__git.init.fish
+++ b/functions/__git.init.fish
@@ -44,8 +44,8 @@ function __git.init
   __git.create_abbr gcav       git commit -a -v --no-verify
   __git.create_abbr gcav!      git commit -a -v --no-verify --amend
   __git.create_abbr gcm        git commit -m
-  __git.create_abbr gcs        git commit -S
   __git.create_abbr gcam       git commit -a -m
+  __git.create_abbr gcs        git commit -S
   __git.create_abbr gscam      git commit -S -a -m
   __git.create_abbr gcfx       git commit --fixup
   __git.create_abbr gcf        git config --list


### PR DESCRIPTION
`gcs` -> `git commit -S` is a really useful abbreviation for my usage (and other who sign their commits) and exists in the Oh My Zsh git plugin. I believe this would be a good addition to this plugin.

The current `gscam` abbreviation does not work for my usecase, since it uses the `-a` option, which is annoying for people like me who like to split their commits and commit all their code at the end.