### PR TITLE
tweaked the gcm abbr to preset the quotation marks

### DIFF
--- a/functions/__git.init.fish
+++ b/functions/__git.init.fish
@@ -15,6 +15,9 @@ function __git.init
     __git.destroy
   end
 
+  # preset the quote pair
+  abbr -a -g --set-cursor='%' -- gcm 'git commit -m "%"'
+  
   # git abbreviations
   __git.create_abbr g          git
   __git.create_abbr ga         git add
@@ -43,7 +46,6 @@ function __git.init
   __git.create_abbr gcv        git commit -v --no-verify
   __git.create_abbr gcav       git commit -a -v --no-verify
   __git.create_abbr gcav!      git commit -a -v --no-verify --amend
-  __git.create_abbr gcm        git commit -m
   __git.create_abbr gcam       git commit -a -m
   __git.create_abbr gcs        git commit -S
   __git.create_abbr gscam      git commit -S -a -m


### PR DESCRIPTION
I have been running the following `gcm` abbr in my config.fish to overwrite the one by default. I was wondering if this would be a better option as a default.

changes gcm from 

`git commit -m`

to 
`git commit -m ""` and moves the cursor back to in-between the quotation marks. 

The `-m` requires a message anyway, so why not use preset them? 

Anyway, I'm open to suggestions of a different implementation but this should be a net improvement as I see it.