### PR TITLE
Check for presence of `$path/functions/__git.init.fish` before sourcing it

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -1,3 +1,9 @@
 # omf initialization.
-source $path/functions/__git.init.fish
+# $path is only defined for oh-my-fish. home-manager activates this plugin by
+# adding the full path of functions/ to fish_function_path, and then sourcing
+# init.fish, so let's skip sourcing __git.init.fish before calling __git.init.
+set -l __git_init_path "$path/functions/__git.init.fish"
+if [ -f "$__git_init_path" ];
+    source "$__git_init_path"
+end
 __git.init


### PR DESCRIPTION
Closes #102.

Test 1: On a home-manager enabled NixOS with fish as default shell, the `gst` abbreviation works, and SSH with jump host works.
Test 2: On an Arch system with fish as default shell and OMF, the `gst` abbreviation works.