### PR TITLE
gunwip: remove extraneous backslashes

### DIFF
--- a/functions/gunwip.fish
+++ b/functions/gunwip.fish
@@ -3,5 +3,5 @@
 # When you want to go back to work, just unwip it
 #
 function gunwip -d "git uncommit the work-in-progress branch"
-  git log -n 1 | grep -q -c "\-\-wip\-\-"; and git reset HEAD~1
+  git log -n 1 | grep -q -c "\--wip--"; and git reset HEAD~1
 end


### PR DESCRIPTION
Fixes `bin/grep: warning: stray \ before -` warnings