### PR TITLE
Add gdg to diff with git's built-in tool when an external tool is the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ gunwip           # restore work in progress
 | gdw          | `git diff --word-diff`                               |
 | gdwc         | `git diff --word-diff --cached`                      |
 | gdto         | `git difftool`                                       |
+| gdg          | `git diff --no-ext-diff`                             |
 | gdv          | pipe `git diff` to `view` command                    |
 
 ### Flow

--- a/functions/__git.init.fish
+++ b/functions/__git.init.fish
@@ -65,6 +65,7 @@ function __git.init
   __git.create_abbr gdw        git diff --word-diff
   __git.create_abbr gdwc       git diff --word-diff --cached
   __git.create_abbr gdto       git difftool
+  __git.create_abbr gdg        git diff --no-ext-diff
   __git.create_abbr gignore    git update-index --assume-unchanged
   __git.create_abbr gf         git fetch
   __git.create_abbr gfa        git fetch --all --prune


### PR DESCRIPTION
Add `gdg` alias to run `git diff --no-ext-diff`, which will force git to do a diff with its own diff utility even when an external one is configured to run by default.