### PR TITLE
Add `gma` -> `git merge --abort`

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ gunwip           # restore work in progress
 | gfm          | `git fetch origin (__git.default_branch) --prune; and git merge FETCH_HEAD` |
 | gfo          | `git fetch origin`                                          |
 | gm           | `git merge`                                                 |
+| gma          | `git merge --abort`                                         |
 | gmt          | `git mergetool --no-prompt`                                 |
 | gmom         | `git merge origin/(__git.default_branch)`                   |
 | grev         | `git revert`                                                |

--- a/functions/__git.init.fish
+++ b/functions/__git.init.fish
@@ -85,6 +85,7 @@ function __git.init
   __git.create_abbr glod       git log --oneline --decorate --color develop..
   __git.create_abbr gloo       "git log --pretty=format:'%C(yellow)%h %Cred%ad %Cblue%an%Cgreen%d %Creset%s' --date=short"
   __git.create_abbr gm         git merge
+  __git.create_abbr gma        git merge --abort
   __git.create_abbr gmt        git mergetool --no-prompt
   __git.create_abbr gmom       git merge origin/\(__git.default_branch\)
   __git.create_abbr gp         git push


### PR DESCRIPTION
Adds an abbreviation for `git merge --abort`: `gma`.