### PR TITLE
feat: Add `grel` alias to show repo directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,11 +353,11 @@ gunwip           # restore work in progress
 | gma          | `git merge --abort`                                         |
 | gmt          | `git mergetool --no-prompt`                                 |
 | gmom         | `git merge origin/(__git.default_branch)`                   |
+| grel         | Print path relative to repository root                      |
 | grev         | `git revert`                                                |
 | grh          | `git reset HEAD`                                            |
 | grhh         | `git reset HEAD --hard`                                     |
 | grhpa        | `git reset --patch`                                         |
-| grd          | Print current repository path                               |
 | grt          | cd into the top of the current repository or submodule      |
 | gsh          | `git show`                                                  |
 | gsd          | `git svn dcommit`                                           |

--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ gunwip           # restore work in progress
 | grh          | `git reset HEAD`                                            |
 | grhh         | `git reset HEAD --hard`                                     |
 | grhpa        | `git reset --patch`                                         |
+| grd          | Print current repository path                               |
 | grt          | cd into the top of the current repository or submodule      |
 | gsh          | `git show`                                                  |
 | gsd          | `git svn dcommit`                                           |

--- a/functions/grd.fish
+++ b/functions/grd.fish
@@ -1,0 +1,4 @@
+function grd -d "Print repository directory" 
+  set -l repoDir (git rev-parse --show-prefix)
+  test -n "$repoDir"; and echo "/$repoDir"; or echo "/"
+end

--- a/functions/grel.fish
+++ b/functions/grel.fish
@@ -1,4 +1,4 @@
-function grd -d "Print repository directory" 
+function grel -d "Print path relative to repository root" 
   set -l repoDir (git rev-parse --show-prefix)
   test -n "$repoDir"; and echo "/$repoDir"; or echo "/"
 end


### PR DESCRIPTION
This commit adds a new `grel`, which can be used to print the path relevant to the repository root.

Example:
```shell
❯ git root
/Users/gavinw/.dotfiles
❯ pwd
/Users/gavinw/.dotfiles/config/zellij
❯ grel
/config/zellij/
❯ grt
❯ grd
/
```